### PR TITLE
Sys 136 remove jenkins trigger from types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,6 @@ jobs:
           npm ci
           echo "Dependency installation complete."
 
-      - name: Build
-        run: |
-          echo "Compiling the code..."
-          npm run compile
-          echo "Compile complete."
-
       - name: Lint
         run: |
           echo "Running Linter..."
@@ -44,6 +38,18 @@ jobs:
           echo "Running format check..."
           npm run format-check
           echo "Format check complete."
+
+      - name: Build
+        run: |
+          echo "Compiling the code..."
+          npm run compile
+          echo "Compile complete."
+
+      - name: Unit Tests
+        run: |
+          echo "Running Unit Tests..."
+          npm test
+          echo "Unit Tests complete."
 
       - name: Test apply patches
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,95 @@
+name: Typescript CI Workflow
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.16.1'
+
+      - name: Install dependencies
+        run: |
+          echo "Installing dependencies..."
+          npm ci
+          echo "Dependency installation complete."
+
+      - name: Build
+        run: |
+          echo "Compiling the code..."
+          npm run compile
+          echo "Compile complete."
+
+      - name: Lint
+        run: |
+          echo "Running Linter..."
+          npm run lint
+          echo "Running Linter complete."
+
+      - name: Format check
+        run: |
+          echo "Running format check..."
+          npm run format-check
+          echo "Format check complete."
+
+      - name: Test apply patches
+        run: |
+          set -e
+          for patch in *.patch; do
+            if [ -f "$patch" ]; then
+              echo "Testing $patch"
+              git apply --check -v "$patch" || (echo "Failed to apply patch: $patch" && exit 1)
+            fi
+          done
+          echo "No patches to test or all patches applied successfully."
+
+  trigger-jenkins:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set Branch Name
+        id: vars
+        run: |
+          # Determine the branch name
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
+          else
+            echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+          fi
+
+          # Determine the repository name, prioritize the secret if it exists
+          if [ -n "${{ vars.REPO_NAME }}" ]; then
+            REPO_NAME=${{ vars.REPO_NAME }}
+          else
+            REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f2)
+          fi
+
+          # Capitalize the repository name
+          REPO_NAME_CAPITALIZED=$(echo "${REPO_NAME:0:1}" | tr '[:lower:]' '[:upper:]')${REPO_NAME:1}
+
+          # Export the environment variables
+          echo "REPO_NAME=${REPO_NAME_CAPITALIZED}" >> $GITHUB_ENV
+
+      - name: Trigger Jenkins Job
+        env:
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+          REPO_NAME: ${{ env.REPO_NAME }}
+          JENKINS_URL: ${{ vars.JENKINS_URL }}
+          JENKINS_JOB_SMOKE: ${{ vars.JENKINS_JOB_SMOKE }}
+        run: |
+          curl -f -X POST "${JENKINS_URL}/job/${JENKINS_JOB_SMOKE}/buildWithParameters?SPECIFY_${REPO_NAME}_BRANCH=true&${REPO_NAME}_BRANCH=${BRANCH_NAME}" \
+            --user "${{ secrets.JENKINS_API_CREDS }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,40 +56,20 @@ jobs:
           done
           echo "No patches to test or all patches applied successfully."
 
-  trigger-jenkins:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set Branch Name
-        id: vars
+      - name: Check if Jenkins Trigger workflow exists
+        id: check-file
         run: |
-          # Determine the branch name
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
+          if [ -f .github/workflows/jenkins-trigger.yml ]; then
+            echo "file_exists=true" >> $GITHUB_ENV
           else
-            echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "file_exists=false" >> $GITHUB_ENV
           fi
 
-          # Determine the repository name, prioritize the secret if it exists
-          if [ -n "${{ vars.REPO_NAME }}" ]; then
-            REPO_NAME=${{ vars.REPO_NAME }}
-          else
-            REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f2)
-          fi
-
-          # Capitalize the repository name
-          REPO_NAME_CAPITALIZED=$(echo "${REPO_NAME:0:1}" | tr '[:lower:]' '[:upper:]')${REPO_NAME:1}
-
-          # Export the environment variables
-          echo "REPO_NAME=${REPO_NAME_CAPITALIZED}" >> $GITHUB_ENV
-
-      - name: Trigger Jenkins Job
-        env:
-          BRANCH_NAME: ${{ env.BRANCH_NAME }}
-          REPO_NAME: ${{ env.REPO_NAME }}
-          JENKINS_URL: ${{ vars.JENKINS_URL }}
-          JENKINS_JOB_SMOKE: ${{ vars.JENKINS_JOB_SMOKE }}
+      - name: Trigger Jenkins Workflow
+        if: env.file_exists == 'true'
         run: |
-          curl -f -X POST "${JENKINS_URL}/job/${JENKINS_JOB_SMOKE}/buildWithParameters?SPECIFY_${REPO_NAME}_BRANCH=true&${REPO_NAME}_BRANCH=${BRANCH_NAME}" \
-            --user "${{ secrets.JENKINS_API_CREDS }}"
+          curl -X POST -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/${{ github.repository }}/dispatches \
+          -d '{"event_type":"trigger-workflow-2"}'
+          echo "Jenkins Workflow triggered!"


### PR DESCRIPTION
Rearranged some steps, added unit test step and updated jenkins trigger to only trigger a step if a jenkins workflow exists. The Jenkins jobs will be triggered in a separate workflow (one won't exist for lib-types for now) and a different ticket will implement code to prevent the workflow from completing successfully if the job fails.